### PR TITLE
Fixes #1 - Improper argument handling in run-peon.py

### DIFF
--- a/run-peon.py
+++ b/run-peon.py
@@ -5,7 +5,6 @@ Script to make running Peon more convienent.
 import os
 import argparse
 import subprocess
-import shlex
 
 CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))
 OUT_FOLDER = os.path.join(CURRENT_PATH, r".out")
@@ -17,20 +16,23 @@ def run_peon(verb, src_folder, dst_folder, texconv_exe_path, fxc_exe_path, packa
     if not os.path.exists(PEON_EXE_PATH):
         raise Exception(f"{PEON_EXE_PATH} does not exist")
     
+    if dst_folder.endswith("\\"):
+        dst_folder = dst_folder.rstrip("\\")
+    
     args = [f"{PEON_EXE_PATH}", f"{verb}"]
-    args.extend([f'--source-folder="{src_folder}"'])
-    args.extend([f'--destination-folder="{dst_folder}"'])
-    args.extend([f'--config-folder="{CONFIG_FOLDER}"'])
-    args.extend([f'--work-folder="{OUT_FOLDER}"'])
-    args.append(f'--delete-unknown')    
+    args.extend([f"--source-folder={src_folder}"])
+    args.extend([f"--destination-folder={dst_folder}"])
+    args.extend([f"--config-folder={CONFIG_FOLDER}"])
+    args.extend([f"--work-folder={OUT_FOLDER}"])
+    args.append(f"--delete-unknown")
     if texconv_exe_path:
-        args.extend([f'--texconv-exe-path="{texconv_exe_path}"'])
+        args.extend([f"--texconv-exe-path={texconv_exe_path}"])
     if fxc_exe_path:
-        args.extend([f'--fxc-exe-path="{fxc_exe_path}"'])
+        args.extend([f"--fxc-exe-path={fxc_exe_path}"])
     if package_mod:
         args.append("--package-mod")
     if verbose:
-        args.append(f"--verbose")
+        args.append("--verbose")
     command_line = str.join(" ", args)
     print("\n{} (cwd={})\n".format(command_line, CURRENT_PATH))
     subprocess.call(command_line, cwd=CURRENT_PATH)


### PR DESCRIPTION
In short, this makes the argument parsing in `run-peon.py` more robust without completely rewriting the script.

The various ways it is used in sins2modtools documentation now all work the same way.

- Remove unused import `shlex`

- Remove quotes around argument values
This removes the need to escape any trailing backslashes when defining file paths.

-  Strip trailing backslashes from `dst_folder`
This covers the edge case when there is an argument supplied after `dst_folder`, such as `-p`.

Example of previous weird behaviour:

This would work
`python .\run-peon.py -s .\examples\mods\super_fast_trader_scout_corvette\ -d .out\super_fast_trader_scout_corvettes\`

This would fail
`python .\run-peon.py -s .\examples\mods\super_fast_trader_scout_corvette\ -d .out\super_fast_trader_scout_corvettes\ -p`

This would work
`python .\run-peon.py -s .\examples\mods\super_fast_trader_scout_corvette\ -d .out\super_fast_trader_scout_corvettes -p`

With this change, it doesn't care whether you add trailing backslashes to your paths or not.
